### PR TITLE
Fix bug and fix swagger

### DIFF
--- a/VirtualAssistantAPI/VirtualAssistantAPI/Controllers/KnowledgeGraphController.cs
+++ b/VirtualAssistantAPI/VirtualAssistantAPI/Controllers/KnowledgeGraphController.cs
@@ -49,7 +49,11 @@ namespace VirtualAssistantAPI.Controllers
             }
             KnowledgeGraph graph = new KnowledgeGraph(new SparQLConnectionFactory());
             var nodes = graph.FindNodes(name);
-            var node = graph.FindNodeInformation(nodes.FirstOrDefault());
+            if (nodes == null || nodes.Count() == 0)
+            {
+                return null;
+            }
+            var node = graph.FindNodeInformation(nodes.First());
             return new JsonResult(node);
         }
     }

--- a/VirtualAssistantAPI/VirtualAssistantAPI/Startup.cs
+++ b/VirtualAssistantAPI/VirtualAssistantAPI/Startup.cs
@@ -40,9 +40,10 @@ namespace VirtualAssistantAPI
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-                app.UseSwagger();
-                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "VirtualAssistantAPI v1"));
             }
+            app.UseSwagger();
+            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "VirtualAssistantAPI v1"));
+
 
             app.UseRouting();
 


### PR DESCRIPTION
Fixed bug, where the virtual assistant crashed if no nodes can be found in the getNode route.

Moved swagger out of the if condition, to allow access to it, even when the Va is running in a docker container